### PR TITLE
feat: resign 기능 추가, scheduler로 30일된 탈퇴회원 자동 삭제

### DIFF
--- a/src/main/java/com/dorandoran/domain/member/controller/AuthController.java
+++ b/src/main/java/com/dorandoran/domain/member/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
     private final MemberRepository memberRepository;
 
     @GetMapping("/me")
-    @Operation(summary = "내 정보 조회", description = "현재 인증된 사용자의 정보를 조회합니다.")
+    @Operation(summary = "내 정보 조회(개발용)", description = "현재 인증된 사용자의 정보를 조회합니다.")
     @SecurityRequirement(name = "bearerAuth")
     public BaseResponse<AuthMemberResponse> getMyInfo(HttpServletRequest request, Principal principal) {
         Long userId = Long.parseLong(principal.getName());

--- a/src/main/java/com/dorandoran/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dorandoran/domain/member/controller/MemberController.java
@@ -44,7 +44,8 @@ public class MemberController {
     @PostMapping("/sendEmail")
     @Operation(summary = "이메일 인증 코드 전송")
     public BaseResponse<Void> sendEmail(
-            @Valid @RequestBody EmailRequest emailDto) {
+            @Valid @RequestBody EmailRequest emailDto
+    ) {
         memberService.sendCodeToEmail(emailDto);
         return BaseResponse.ok(SuccessCode.EMAIL_SEND_SUCCESS);
     }
@@ -60,7 +61,10 @@ public class MemberController {
 
     @PostMapping("/login")
     @Operation(summary = "로그인")
-    public BaseResponse<Void> login(@Valid @RequestBody LoginRequest dto, HttpServletResponse response) {
+    public BaseResponse<Void> login(
+            @Valid @RequestBody LoginRequest dto,
+            HttpServletResponse response
+    ) {
         MemberTokenResponse token = memberService.login(dto);
         addJwtTokenResponse(response, token);
         return BaseResponse.ok(SuccessCode.LOGIN_SUCCESS);
@@ -71,7 +75,8 @@ public class MemberController {
     @SecurityRequirement(name = "bearerAuth")   // Swagger 에서 Bearer 인증 필요함을 명시
     public BaseResponse<Void> logout(
             HttpServletResponse response,
-            Principal principal) {
+            Principal principal
+    ) {
         // memberService.logout 에서 Redis 에서 refresh token 삭제
         memberService.logout(principal.getName());
 
@@ -83,8 +88,12 @@ public class MemberController {
     @PatchMapping("/resign")
     @Operation(summary = "회원 탈퇴")
     @SecurityRequirement(name = "bearerAuth")
-    public BaseResponse<Void> resign(Principal principal) {
+    public BaseResponse<Void> resign(
+            HttpServletResponse response,
+            Principal principal
+    ) {
         memberService.resign(principal.getName());
+        deleteRefreshTokenCookie(response);
         return BaseResponse.ok(SuccessCode.RESIGN_SUCCESS);
     }
 

--- a/src/main/java/com/dorandoran/domain/member/entity/Member.java
+++ b/src/main/java/com/dorandoran/domain/member/entity/Member.java
@@ -11,12 +11,18 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+// 모든 조회 시 DELETED 상태의 회원 제외
+@SQLRestriction("status != 'DELETED'")
+// memberRepository.delete() 호출 시 status를 DELETED로 변경, deletedAt 현재 시간으로 설정
+@SQLDelete(sql = "UPDATE member SET status = 'DELETED', deleted_at = NOW() WHERE id = ?")
 public class Member extends BaseTime {
 
     @Column(nullable = false, unique = true)
@@ -50,11 +56,6 @@ public class Member extends BaseTime {
         this.nickname = nickname;
         this.role = role;
         this.status = status;
-    }
-
-    public void withdraw() {
-        this.status = MemberStatus.DELETED;
-        this.deletedAt = LocalDateTime.now();
     }
 
     public static Member createMember(String username, String password, String email, String nickname) {

--- a/src/main/java/com/dorandoran/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dorandoran/domain/member/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package com.dorandoran.domain.member.repository;
 
 import com.dorandoran.domain.member.entity.Member;
+import com.dorandoran.domain.member.type.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -15,4 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByEmail(String email);
+
+    @Modifying
+    @Query("DELETE FROM Member m WHERE m.status = :memberStatus AND m.deletedAt < :threshold")
+    void deleteAllByStatusDeletedAndBefore(MemberStatus memberStatus, LocalDateTime threshold);
 }

--- a/src/main/java/com/dorandoran/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/dorandoran/domain/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,18 @@
+package com.dorandoran.domain.member.scheduler;
+
+import com.dorandoran.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private final MemberService memberService;
+
+    @Scheduled(cron = "0 0 5 * * *") // 매일 오전 5시에 실행
+    public void cleanUp() {
+        memberService.deleteExpiredMember();
+    }
+}

--- a/src/main/java/com/dorandoran/global/response/ErrorCode.java
+++ b/src/main/java/com/dorandoran/global/response/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     DUPLICATED_USERNAME(HttpStatus.BAD_REQUEST, "중복된 아이디입니다."),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     // JWT 오류
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/test/java/com/dorandoran/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dorandoran/domain/member/controller/MemberControllerTest.java
@@ -17,6 +17,7 @@ import static com.dorandoran.global.response.SuccessCode.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -169,5 +170,26 @@ class MemberControllerTest extends SpringBootTestSupporter {
 
         // RedisRepository mock에 대해 deleteRefreshToken이 호출됐는지 검증
         verify(redisRepository).deleteRefreshToken(member.getUsername());
+    }
+
+    @DisplayName("resign 테스트")
+    @Test
+    void resign() throws Exception {
+        // given
+        Member member = memberFactory.saveAndCreateMember(1).getFirst();
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/api/v1/members/resign")
+                .with(user(String.valueOf(member.getId())).roles("MEMBER"))
+                .contentType("application/json"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(RESIGN_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.code").value(RESIGN_SUCCESS.getHttpStatus().value()));
+
+        // RedisRepository mock에 대해 deleteRefreshToken이 호출됐는지 검증
+        verify(redisRepository).deleteRefreshToken(String.valueOf(member.getId()));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요. ex) #3

#6 
  <br/>

## ✔️PR Checklist

- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

- 회원 탈퇴기능 soft delete로 구현
- 탈퇴된 회원은 모든 로직에서 조회 안되게 설정
- 탈퇴된 회원은 30일이 지나면 db에서 삭제되게 스케쥴러 처리